### PR TITLE
Export AuthError and CacheAuthError synonyms

### DIFF
--- a/jwt-bearer-auth-yesod/src/Web/Auth/Bearer/JWT/Yesod.hs
+++ b/jwt-bearer-auth-yesod/src/Web/Auth/Bearer/JWT/Yesod.hs
@@ -4,13 +4,15 @@
 -- |
 -- This module provides JWT Bearer authentication for Yesod applications.
 module Web.Auth.Bearer.JWT.Yesod
-  ( authorizeWithJWT
-  , isAuthorizedJWKCache
+  ( AuthError
+  , CacheAuthError
+  , JWKCache
+  , authorizeWithJWT
   , handleCacheErrors
   , handleDefaultErrors
-  , JWKCache
-  , withCacheSettings
+  , isAuthorizedJWKCache
   , module Web.Auth.Bearer.JWT.Yesod.Types
+  , withCacheSettings
   ) where
 
 import Prelude


### PR DESCRIPTION
I realized in Progress I was duplicating a type synonym for this, it should instead use these from the library
